### PR TITLE
ManifestAssetResolver: use always forward slash as it can contain HTTP URI which does not support backslashes

### DIFF
--- a/src/AssetResolver/ManifestAssetResolver.php
+++ b/src/AssetResolver/ManifestAssetResolver.php
@@ -24,7 +24,7 @@ final class ManifestAssetResolver implements AssetResolverInterface
 
 	public function __construct(string $manifestName, BuildDirectoryProvider $directoryProvider)
 	{
-		$this->manifestPath = $directoryProvider->getBuildDirectory() . DIRECTORY_SEPARATOR . $manifestName;
+		$this->manifestPath = $directoryProvider->getBuildDirectory() . '/' . $manifestName;
 	}
 
 


### PR DESCRIPTION
for local file paths forward slashes are allowed for Linux, Mac OS and Windows