### PR TITLE
Optionally load manifest file in compile-time for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,17 @@ webpack:
 
 You might want to include the Webpack's asset hash in its file name for assets caching (and automatic cache busting in new releases) in the user agent. But how do you reference the asset files in your code if their names are dynamic?
 
-WebpackNetteAdapter comes to the rescue. You can employ the [webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin) or some similar plugin to produce a manifest file, and then switch the asset resolver accordingly:
+WebpackNetteAdapter comes to the rescue. You can employ the [webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin) or some similar plugin to produce a manifest file, and then configure the adapter to use it:
 
 ```yaml
 webpack:
-	assetResolver: Oops\WebpackNetteAdapter\AssetResolver\ManifestAssetNameResolver(manifest.json)
+	manifest:
+		name: manifest.json
 ```
 
 This way, you can keep using the original asset names, and they get expanded automatically following the resolutions from the manifest file.
+
+WebpackNetteAdapter automatically optimizes this in production environment by loading the manifest file in compile time.
 
 
 ### Debugger

--- a/src/AssetNameResolver/StaticAssetNameResolver.php
+++ b/src/AssetNameResolver/StaticAssetNameResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\WebpackNetteAdapter\AssetNameResolver;
+
+
+final class StaticAssetNameResolver implements AssetNameResolverInterface
+{
+
+	/**
+	 * @var string[]
+	 */
+	private $resolutions;
+
+
+	public function __construct(array $resolutions)
+	{
+		$this->resolutions = $resolutions;
+	}
+
+
+	public function resolveAssetName(string $asset): string
+	{
+		if ( ! isset($this->resolutions[$asset])) {
+			throw new CannotResolveAssetNameException(sprintf(
+				"Asset '%s' was not found in the resolutions array",
+				$asset
+			));
+		}
+
+		return $this->resolutions[$asset];
+	}
+
+}

--- a/src/Manifest/CannotLoadManifestException.php
+++ b/src/Manifest/CannotLoadManifestException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\WebpackNetteAdapter\Manifest;
+
+
+class CannotLoadManifestException extends \RuntimeException
+{
+}

--- a/src/Manifest/ManifestLoader.php
+++ b/src/Manifest/ManifestLoader.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Oops\WebpackNetteAdapter\Manifest;
+
+use Nette\Utils\Json;
+use Oops\WebpackNetteAdapter\BuildDirectoryProvider;
+
+
+/**
+ * @internal
+ */
+class ManifestLoader
+{
+
+	/**
+	 * @var BuildDirectoryProvider
+	 */
+	private $directoryProvider;
+
+
+	public function __construct(BuildDirectoryProvider $directoryProvider)
+	{
+		$this->directoryProvider = $directoryProvider;
+	}
+
+
+	/**
+	 * @throws CannotLoadManifestException
+	 */
+	public function loadManifest(string $fileName): array
+	{
+		$path = $this->getManifestPath($fileName);
+		$context = stream_context_create(['ssl' => ['verify_peer' => FALSE]]); // webpack-dev-server uses self-signed certificate
+		$manifest = @file_get_contents($path, FALSE, $context); // @ - errors handled by custom exception
+
+		if ($manifest === FALSE) {
+			throw new CannotLoadManifestException(sprintf(
+				"Manifest file '%s' could not be loaded: %s",
+				$path, error_get_last()['message'] ?? 'unknown error'
+			));
+		}
+
+		return Json::decode($manifest, Json::FORCE_ARRAY);
+	}
+
+
+	public function getManifestPath(string $fileName): string
+	{
+		return $this->directoryProvider->getBuildDirectory() . '/' . $fileName;
+	}
+
+}

--- a/tests/WebpackNetteAdapter/AssetNameResolver/ManifestAssetNameResolverTest.phpt
+++ b/tests/WebpackNetteAdapter/AssetNameResolver/ManifestAssetNameResolverTest.phpt
@@ -6,8 +6,7 @@ namespace OopsTests\WebpackNetteAdapter\AssetNameResolver;
 
 use Oops\WebpackNetteAdapter\AssetNameResolver\CannotResolveAssetNameException;
 use Oops\WebpackNetteAdapter\AssetNameResolver\ManifestAssetNameResolver;
-use Oops\WebpackNetteAdapter\BuildDirectoryProvider;
-use Oops\WebpackNetteAdapter\DevServer;
+use Oops\WebpackNetteAdapter\Manifest\ManifestLoader;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,9 +22,15 @@ class ManifestAssetNameResolverTest extends TestCase
 
 	public function testResolver()
 	{
-		$devServer = \Mockery::mock(DevServer::class);
-		$devServer->shouldReceive('isAvailable')->andReturn(FALSE);
-		$resolver = new ManifestAssetNameResolver('manifest.json', new BuildDirectoryProvider(__DIR__, $devServer));
+		$manifestLoader = \Mockery::mock(ManifestLoader::class);
+		$manifestLoader->shouldReceive('loadManifest')
+			->with('manifest.json')
+			->andReturn(['asset.js' => 'resolved.asset.js']);
+
+		$manifestLoader->shouldReceive('getManifestPath')
+			->andReturn('/path/to/manifest.json');
+
+		$resolver = new ManifestAssetNameResolver('manifest.json', $manifestLoader);
 		Assert::same('resolved.asset.js', $resolver->resolveAssetName('asset.js'));
 
 		Assert::throws(function () use ($resolver) {

--- a/tests/WebpackNetteAdapter/AssetNameResolver/StaticAssetNameResolverTest.phpt
+++ b/tests/WebpackNetteAdapter/AssetNameResolver/StaticAssetNameResolverTest.phpt
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace OopsTests\WebpackNetteAdapter\AssetNameResolver;
+
+use Oops\WebpackNetteAdapter\AssetNameResolver\CannotResolveAssetNameException;
+use Oops\WebpackNetteAdapter\AssetNameResolver\StaticAssetNameResolver;
+use Tester\Assert;
+use Tester\TestCase;
+
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+/**
+ * @testCase
+ */
+class StaticAssetNameResolverTest extends TestCase
+{
+
+	public function testResolver()
+	{
+		$resolver = new StaticAssetNameResolver([
+			'asset.js' => 'cached.resolved.asset.js',
+		]);
+
+		Assert::same('cached.resolved.asset.js', $resolver->resolveAssetName('asset.js'));
+	}
+
+
+	public function testCannotResolveAsset()
+	{
+		$resolver = new StaticAssetNameResolver([
+			'asset.js' => 'cached.resolved.asset.js',
+		]);
+
+		Assert::throws(function () use ($resolver) {
+			$resolver->resolveAssetName('unknownAsset.js');
+		}, CannotResolveAssetNameException::class);
+	}
+
+}
+
+
+(new StaticAssetNameResolverTest())->run();

--- a/tests/WebpackNetteAdapter/DI/WebpackExtensionTest.phpt
+++ b/tests/WebpackNetteAdapter/DI/WebpackExtensionTest.phpt
@@ -13,6 +13,7 @@ use Oops\WebpackNetteAdapter\AssetNameResolver\AssetNameResolverInterface;
 use Oops\WebpackNetteAdapter\AssetNameResolver\DebuggerAwareAssetNameResolver;
 use Oops\WebpackNetteAdapter\AssetNameResolver\IdentityAssetNameResolver;
 use Oops\WebpackNetteAdapter\AssetNameResolver\ManifestAssetNameResolver;
+use Oops\WebpackNetteAdapter\AssetNameResolver\StaticAssetNameResolver;
 use Oops\WebpackNetteAdapter\Debugging\WebpackPanel;
 use Oops\WebpackNetteAdapter\DevServer;
 use Oops\WebpackNetteAdapter\DI\ConfigurationException;
@@ -88,6 +89,21 @@ class WebpackExtensionTest extends TestCase
 	}
 
 
+	public function testOptimizedManifest()
+	{
+		$container = $this->createContainer('optimizedManifest');
+		$resolver = $container->getByType(AssetNameResolverInterface::class);
+
+		Assert::type(StaticAssetNameResolver::class, $resolver);
+
+		$refl = new \ReflectionClass($resolver);
+		$cache = $refl->getProperty('resolutions');
+		$cache->setAccessible(TRUE);
+
+		Assert::same(["asset.js" => "cached.resolved.asset.js"], $cache->getValue($resolver));
+	}
+
+
 	public function testLatte()
 	{
 		$container = $this->createContainer('noDebug');
@@ -109,6 +125,8 @@ class WebpackExtensionTest extends TestCase
 		$configurator = new Configurator();
 		$configurator->setTempDirectory(TEMP_DIR);
 		$configurator->setDebugMode(FALSE);
+
+		$configurator->addParameters(['buildDir' => __DIR__]);
 		$configurator->addConfig(__DIR__ . '/config/common.neon');
 		$configurator->addConfig(__DIR__ . '/config/' . $configFile . '.neon');
 

--- a/tests/WebpackNetteAdapter/DI/config/basic.neon
+++ b/tests/WebpackNetteAdapter/DI/config/basic.neon
@@ -4,7 +4,7 @@ extensions:
 
 webpack:
 	build:
-		directory: %wwwDir%
+		directory: %buildDir%
 		publicPath: dist/
 
 	devServer:

--- a/tests/WebpackNetteAdapter/DI/config/manifest.neon
+++ b/tests/WebpackNetteAdapter/DI/config/manifest.neon
@@ -4,7 +4,9 @@ extensions:
 
 webpack:
 	build:
-		directory: %wwwDir%
+		directory: %buildDir%
 		publicPath: dist/
 
-	assetResolver: Oops\WebpackNetteAdapter\AssetNameResolver\ManifestAssetNameResolver(manifest.json)
+	manifest:
+		name: manifest.json
+		optimize: false

--- a/tests/WebpackNetteAdapter/DI/config/optimizedManifest.neon
+++ b/tests/WebpackNetteAdapter/DI/config/optimizedManifest.neon
@@ -6,3 +6,6 @@ webpack:
 	build:
 		directory: %buildDir%
 		publicPath: dist/
+
+	manifest:
+		name: optimizedManifest.json

--- a/tests/WebpackNetteAdapter/DI/optimizedManifest.json
+++ b/tests/WebpackNetteAdapter/DI/optimizedManifest.json
@@ -1,0 +1,3 @@
+{
+	"asset.js": "cached.resolved.asset.js"
+}

--- a/tests/WebpackNetteAdapter/Manifest/ManifestLoaderTest.phpt
+++ b/tests/WebpackNetteAdapter/Manifest/ManifestLoaderTest.phpt
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace OopsTests\WebpackNetteAdapter\Manifest;
+
+use Oops\WebpackNetteAdapter\BuildDirectoryProvider;
+use Oops\WebpackNetteAdapter\Manifest\CannotLoadManifestException;
+use Oops\WebpackNetteAdapter\Manifest\ManifestLoader;
+use Tester\Assert;
+use Tester\TestCase;
+
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+/**
+ * @testCase
+ */
+class ManifestLoaderTest extends TestCase
+{
+
+	public function testLoader()
+	{
+		$buildDirProvider = \Mockery::mock(BuildDirectoryProvider::class);
+		$buildDirProvider->shouldReceive('getBuildDirectory')->andReturn(__DIR__);
+		$manifestLoader = new ManifestLoader($buildDirProvider);
+
+		Assert::same(__DIR__ . '/manifest.json', $manifestLoader->getManifestPath('manifest.json'));
+		Assert::same(['asset.js' => 'resolved.asset.js'], $manifestLoader->loadManifest('manifest.json'));
+
+		Assert::throws(function () use ($manifestLoader) {
+			$manifestLoader->loadManifest('unknown.js');
+		}, CannotLoadManifestException::class);
+
+		\Mockery::close();
+	}
+
+}
+
+
+(new ManifestLoaderTest())->run();

--- a/tests/WebpackNetteAdapter/Manifest/manifest.json
+++ b/tests/WebpackNetteAdapter/Manifest/manifest.json
@@ -1,0 +1,3 @@
+{
+	"asset.js": "resolved.asset.js"
+}


### PR DESCRIPTION
This also changes manifest configuration **(BC break!)**

from:

```yaml
webpack:
    assetResolver: Oops\WebpackNetteAdapter\AssetResolver\ManifestAssetResolver(manifest.json)
```

to

```yaml
webpack:
    manifest:
        name: manifest.json
```

The optimization can be turned on and off via `webpack.manifest.optimize` option, which defaults to `%productionMode%`