### PR TITLE
Proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ webpack:
         timeout: 0.1 # (seconds) default
 ```
 
+### Public url (eg. Docker usage)
+Devserver might have different url when accessed from Nette and different url from other applications (eg. when running in Docker). For this set up `publicUrl`.   
+
+```yaml
+webpack:
+    devServer:
+        enabled: %debugMode% # default
+        url: http://localhost:3000
+        publicUrl: http://localhost:3030
+```
+
 
 ### Asset resolvers and manifest file
 

--- a/src/DI/WebpackExtension.php
+++ b/src/DI/WebpackExtension.php
@@ -32,6 +32,7 @@ class WebpackExtension extends CompilerExtension
 		'devServer' => [
 			'enabled' => NULL,
 			'url' => NULL,
+			'proxy' => NULL,
             'timeout' => 0.1,
 		],
 		'build' => [
@@ -90,6 +91,7 @@ class WebpackExtension extends CompilerExtension
 			->setFactory(DevServer::class, [
 				$config['devServer']['enabled'],
 				$config['devServer']['url'] ?? '',
+				$config['devServer']['proxy'] ?? '',
 				$config['devServer']['timeout'],
 				new Statement(Client::class)
 			]);
@@ -156,6 +158,7 @@ class WebpackExtension extends CompilerExtension
 				$devServerInstance = new DevServer(
 					$config['devServer']['enabled'],
 					$config['devServer']['url'] ?? '',
+					$config['devServer']['proxy'] ?? '',
 					$config['devServer']['timeout'] ?? 0.1,
 					new Client()
 				);

--- a/src/DI/WebpackExtension.php
+++ b/src/DI/WebpackExtension.php
@@ -32,7 +32,7 @@ class WebpackExtension extends CompilerExtension
 		'devServer' => [
 			'enabled' => NULL,
 			'url' => NULL,
-			'proxy' => NULL,
+			'publicUrl' => NULL,
             'timeout' => 0.1,
 		],
 		'build' => [
@@ -91,7 +91,7 @@ class WebpackExtension extends CompilerExtension
 			->setFactory(DevServer::class, [
 				$config['devServer']['enabled'],
 				$config['devServer']['url'] ?? '',
-				$config['devServer']['proxy'] ?? '',
+				$config['devServer']['publicUrl'] ?? '',
 				$config['devServer']['timeout'],
 				new Statement(Client::class)
 			]);
@@ -158,7 +158,7 @@ class WebpackExtension extends CompilerExtension
 				$devServerInstance = new DevServer(
 					$config['devServer']['enabled'],
 					$config['devServer']['url'] ?? '',
-					$config['devServer']['proxy'] ?? '',
+					$config['devServer']['publicUrl'] ?? '',
 					$config['devServer']['timeout'] ?? 0.1,
 					new Client()
 				);

--- a/src/DevServer.php
+++ b/src/DevServer.php
@@ -26,6 +26,11 @@ class DevServer
 	 */
 	private $url;
 
+	/**
+	 * @var string
+	 */
+	private $proxy;
+
     /**
      * @var float
      */
@@ -37,10 +42,11 @@ class DevServer
 	private $httpClient;
 
 
-	public function __construct(bool $enabled, string $url, float $timeout, ClientInterface $httpClient)
+	public function __construct(bool $enabled, string $url, string $proxy, float $timeout, ClientInterface $httpClient)
 	{
 		$this->enabled = $enabled;
 		$this->url = $url;
+		$this->proxy = $proxy;
 		$this->timeout = $timeout;
 		$this->httpClient = $httpClient;
 	}
@@ -48,7 +54,7 @@ class DevServer
 
 	public function getUrl(): string
 	{
-		return $this->url;
+		return $this->proxy ? $this->proxy : $this->url;
 	}
 
 

--- a/src/DevServer.php
+++ b/src/DevServer.php
@@ -29,7 +29,7 @@ class DevServer
 	/**
 	 * @var string
 	 */
-	private $proxy;
+	private $publicUrl;
 
     /**
      * @var float
@@ -42,11 +42,11 @@ class DevServer
 	private $httpClient;
 
 
-	public function __construct(bool $enabled, string $url, string $proxy, float $timeout, ClientInterface $httpClient)
+	public function __construct(bool $enabled, string $url, string $publicUrl, float $timeout, ClientInterface $httpClient)
 	{
 		$this->enabled = $enabled;
 		$this->url = $url;
-		$this->proxy = $proxy;
+		$this->publicUrl = $publicUrl;
 		$this->timeout = $timeout;
 		$this->httpClient = $httpClient;
 	}
@@ -54,7 +54,7 @@ class DevServer
 
 	public function getUrl(): string
 	{
-		return $this->proxy ? $this->proxy : $this->url;
+		return $this->publicUrl ?? $this->url;
 	}
 
 

--- a/tests/WebpackNetteAdapter/DevServerTest.phpt
+++ b/tests/WebpackNetteAdapter/DevServerTest.phpt
@@ -48,6 +48,20 @@ class DevServerTest extends TestCase
 	}
 
 
+	public function testPublicUrl(): void
+	{
+	    $devServer = new DevServer(TRUE, 'http://localhost:3000', 'http://localhost:3030', 0.1, $this->httpClient);
+	    Assert::true($devServer->isEnabled());
+	    Assert::same($devServer->getUrl(), 'http://localhost:3030');
+
+	    $this->httpClient->shouldReceive('request')
+	        ->with('GET', 'http://localhost:3000', ['http_errors' => FALSE, 'verify' => FALSE, 'timeout' => 0.1])
+	        ->andReturn(new Response(404));
+
+        Assert::true($devServer->isAvailable());
+	}
+
+
 	public function testUnavailable(): void
 	{
 		$devServer = new DevServer(TRUE, 'http://localhost:3000', '', 0.5, $this->httpClient);

--- a/tests/WebpackNetteAdapter/DevServerTest.phpt
+++ b/tests/WebpackNetteAdapter/DevServerTest.phpt
@@ -38,7 +38,7 @@ class DevServerTest extends TestCase
 
 	public function testDevServer(): void
 	{
-		$devServer = new DevServer(TRUE, 'http://localhost:3000', 0.1, $this->httpClient);
+		$devServer = new DevServer(TRUE, 'http://localhost:3000', '', 0.1, $this->httpClient);
 		Assert::true($devServer->isEnabled());
 
 		$this->httpClient->shouldReceive('request')
@@ -50,7 +50,7 @@ class DevServerTest extends TestCase
 
 	public function testUnavailable(): void
 	{
-		$devServer = new DevServer(TRUE, 'http://localhost:3000', 0.5, $this->httpClient);
+		$devServer = new DevServer(TRUE, 'http://localhost:3000', '', 0.5, $this->httpClient);
 		Assert::true($devServer->isEnabled());
 
 		$this->httpClient->shouldReceive('request')
@@ -62,7 +62,7 @@ class DevServerTest extends TestCase
 
 	public function testDisabled(): void
 	{
-		$devServer = new DevServer(FALSE, 'http://localhost:3000', 0.1, $this->httpClient);
+		$devServer = new DevServer(FALSE, 'http://localhost:3000', '', 0.1, $this->httpClient);
 		Assert::false($devServer->isEnabled());
 		Assert::false($devServer->isAvailable());
 	}


### PR DESCRIPTION
With combination Nette + Docker + Webpack I need to tell browser for a different assets URL. I added a proxy URL setting. 